### PR TITLE
add phone battery bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A simple, clean Pebble watchface with a large, easy-to-read font. Displays the e
 - **Weather** -- current temperature and conditions via [Open-Meteo](https://open-meteo.com/) (no API key required), with configurable temperature unit and update interval
 - **Sunrise & sunset times** -- sun times from your location. Uses times from [Open-Meteo](https://open-meteo.com/) if weather is enabled, otherwise calculated on device
 - **Moon phase** -- 29-phase moon icon and weather conditions use the [weather-icons](https://github.com/erikflowers/weather-icons) font
-- **Battery meter** -- color-coded bar (green/yellow/red) with fallback to black and white
+- **Watch battery meter** -- color-coded bar (green/yellow/red) with fallback to black and white
+- **Phone battery meter** -- reports the connected phone's battery life from supported  devices
 - **Bluetooth indicator** -- icon and optional vibration alert on disconnect
 - **Hourly vibration** -- optional periodic pulse
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,12 @@
       "ShowSun",
       "ShowMoon",
       "PeriodicVibrate",
-      "BluetoothVibrate"
+      "BluetoothVibrate",
+      "ShowPhoneBattery",
+      "REQUEST_BATTERY",
+      "REQUEST_BATTERY_UNSUBSCRIBE",
+      "BATTERY",
+      "JSReady"
     ],
     "resources": {
       "media": [

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
       "ShowPhoneBattery",
       "REQUEST_BATTERY",
       "REQUEST_BATTERY_UNSUBSCRIBE",
-      "BATTERY",
-      "JSReady"
+      "BATTERY"
     ],
     "resources": {
       "media": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BigInfo",
   "author": "drod",
-  "version": "1.1",
+  "version": "1.2",
   "keywords": [
     "weather",
     "moon",

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -20,6 +20,7 @@ typedef struct ClaySettings {
   bool ShowSteps;
   bool ShowSun;
   bool ShowMoon;
+  bool ShowPhoneBattery;
   bool PeriodicVibrate;
   bool BluetoothVibrate;
   // storage
@@ -29,10 +30,12 @@ typedef struct ClaySettings {
   int MoonPhase;
   int WeatherTemp;
   int WeatherIcon;
+  int PhoneBattery;
 } ClaySettings;
 
 // An instance of the struct
 static ClaySettings settings;
+static bool s_js_ready;
 
 static Window *s_main_window;
 static TextLayer *s_time_layer;
@@ -55,6 +58,7 @@ static GFont s_weather_font;
 // Battery
 static Layer *s_battery_layer;
 static int s_battery_level;
+static Layer *s_phone_battery_layer;
 
 // Unobstructed area
 static Layer *s_window_layer;
@@ -76,6 +80,7 @@ static void prv_default_settings() {
   settings.ShowSteps = false;
   settings.ShowSun = false;
   settings.ShowMoon = false;
+  settings.ShowPhoneBattery = false;
   settings.PeriodicVibrate = false;
   settings.BluetoothVibrate = false;
   // storage
@@ -85,6 +90,7 @@ static void prv_default_settings() {
   settings.MoonPhase=29;
   settings.WeatherTemp=-99;
   settings.WeatherIcon=15;
+  settings.PhoneBattery=0;
 }
 
 static char* weather_conditions[] = {
@@ -205,9 +211,11 @@ static void prv_update_display() {
   layer_set_hidden(text_layer_get_layer(s_sunrise_layer), !settings.ShowSun);
   layer_set_hidden(text_layer_get_layer(s_sunset_layer), !settings.ShowSun);
   layer_set_hidden(text_layer_get_layer(s_moon_layer), !settings.ShowMoon);
+  layer_set_hidden(s_phone_battery_layer, !settings.ShowPhoneBattery);
 
   // Mark battery layer for redraw (color may have changed)
   layer_mark_dirty(s_battery_layer);
+  layer_mark_dirty(s_phone_battery_layer);
 }
 
 static void update_time() {
@@ -322,11 +330,11 @@ static void battery_callback(BatteryChargeState state) {
   layer_mark_dirty(s_battery_layer);
 }
 
-static void battery_update_proc(Layer *layer, GContext *ctx) {
+static void battery_update_proc(Layer *layer, GContext *ctx, int battery_level) {
   GRect bounds = layer_get_bounds(layer);
 
   // Find the width of the bar (inside the border)
-  int bar_width = ((s_battery_level * (bounds.size.w - 4)) / 100);
+  int bar_width = ((battery_level * (bounds.size.w - 4)) / 100);
 
   // Draw the border using the text color
   graphics_context_set_stroke_color(ctx, settings.TextColor);
@@ -334,9 +342,9 @@ static void battery_update_proc(Layer *layer, GContext *ctx) {
 
   // Choose color based on battery level
   GColor bar_color;
-  if (s_battery_level <= 20) {
+  if (battery_level <= 20) {
     bar_color = PBL_IF_COLOR_ELSE(GColorRed, settings.TextColor);
-  } else if (s_battery_level <= 40) {
+  } else if (battery_level <= 40) {
     bar_color = PBL_IF_COLOR_ELSE(GColorChromeYellow, settings.TextColor);
   } else {
     bar_color = PBL_IF_COLOR_ELSE(GColorGreen, settings.TextColor);
@@ -345,6 +353,14 @@ static void battery_update_proc(Layer *layer, GContext *ctx) {
   // Draw the filled bar inside the border
   graphics_context_set_fill_color(ctx, bar_color);
   graphics_fill_rect(ctx, GRect(2, 2, bar_width, bounds.size.h - 4), 1, GCornerNone);
+}
+
+static void watch_battery_update_proc(Layer *layer, GContext *ctx) {
+  battery_update_proc(layer, ctx, s_battery_level);
+}
+
+static void phone_battery_update_proc(Layer *layer, GContext *ctx) {
+  battery_update_proc(layer, ctx, settings.PhoneBattery);
 }
 
 static void bluetooth_callback(bool connected) {
@@ -366,6 +382,13 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   bool prev_NightTheme = settings.NightTheme;
   bool prev_ShowWeather = settings.ShowWeather;
   bool prev_TemperatureUnit = settings.TemperatureUnit;
+  bool prev_ShowPhoneBattery = settings.ShowPhoneBattery;
+
+  // chekc if PebbleKit JS is ready
+  Tuple *ready_tuple = dict_find(iterator, MESSAGE_KEY_JSReady);
+  if (ready_tuple) {
+    s_js_ready = true;
+  }
 
   // Check for Clay settings data
   Tuple *bg_color_day_t = dict_find(iterator, MESSAGE_KEY_BackgroundColorDay);
@@ -417,6 +440,10 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   if (show_moon_t) {
     settings.ShowMoon = show_moon_t->value->int32 == 1;
   }
+  Tuple *show_phone_battery_t = dict_find(iterator, MESSAGE_KEY_ShowPhoneBattery);
+  if (show_phone_battery_t) {
+    settings.ShowPhoneBattery = show_phone_battery_t->value->int32 == 1;
+  }
   Tuple *periodic_vibrate_t = dict_find(iterator, MESSAGE_KEY_PeriodicVibrate);
   if (periodic_vibrate_t) {
     settings.PeriodicVibrate = periodic_vibrate_t->value->int32 == 1;
@@ -460,8 +487,30 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     update_moon();
   }
 
+  // check for battery data
+  Tuple *battery_tuple = dict_find(iterator, MESSAGE_KEY_BATTERY);
+  if (battery_tuple) {
+    settings.PhoneBattery = (int)battery_tuple->value->int32;
+    layer_mark_dirty(s_phone_battery_layer);
+  }
+
   // Save and apply if any settings were changed
-  if (bg_color_day_t || text_color_day_t || bg_color_night_t || text_color_night_t || night_theme_t || temp_unit_t || show_weather_t || show_date_t || show_steps_t || show_sun_t || show_moon_t) {
+  if (bg_color_day_t || text_color_day_t || bg_color_night_t || text_color_night_t || night_theme_t || temp_unit_t || show_weather_t || show_date_t || show_steps_t || show_sun_t || show_moon_t || show_phone_battery_t) {
+    
+    // if show battery was toggled
+    if (prev_ShowPhoneBattery != settings.ShowPhoneBattery) {
+      int bar_offset = (PBL_DISPLAY_HEIGHT / 6);
+      int bar_height = (PBL_DISPLAY_HEIGHT / 24);
+      int bar_width = PBL_DISPLAY_WIDTH / 1.1;
+      int bar_x = (PBL_DISPLAY_WIDTH - bar_width) / 2;
+      int bar_y = PBL_DISPLAY_HEIGHT - (bar_offset - (PBL_DISPLAY_HEIGHT / 12));
+      if (settings.ShowPhoneBattery) {
+        bar_width = (bar_width / 2) - (bar_x / 2);
+      }
+      layer_set_frame(s_battery_layer, GRect(bar_x, bar_y, bar_width, bar_height));
+      layer_mark_dirty(s_battery_layer);
+    }
+    
     prv_save_settings();
     prv_update_display();
     // Only request data when a setting was actually changed
@@ -469,7 +518,9 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
                    (!prev_ShowMoon && settings.ShowMoon) ||
                    (!prev_NightTheme && settings.NightTheme);
     bool requestWeather = ((prev_TemperatureUnit != settings.TemperatureUnit) || !prev_ShowWeather) && settings.ShowWeather;
-    if (requestSun || requestWeather) {
+    bool requestBattery = (!prev_ShowPhoneBattery && settings.ShowPhoneBattery);
+    bool unsibscribeBattery = (prev_ShowPhoneBattery && !settings.ShowPhoneBattery);
+    if (requestSun || requestWeather || requestBattery || unsibscribeBattery) {
       DictionaryIterator *iter;
       app_message_outbox_begin(&iter);
       if (requestSun) {
@@ -478,9 +529,15 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
       if (requestWeather) {
         dict_write_uint8(iter, MESSAGE_KEY_REQUEST_WEATHER, 1);
       }
+      if (requestBattery) {
+        dict_write_uint8(iter, MESSAGE_KEY_REQUEST_BATTERY, 1);
+      }
+      if (unsibscribeBattery) {
+        dict_write_uint8(iter, MESSAGE_KEY_REQUEST_BATTERY_UNSUBSCRIBE, 1);
+      }
       app_message_outbox_send();
     }
-  } else if (temp_tuple || conditions_tuple || sunrise_tuple || sunset_tuple || moon_tuple) {
+  } else if (temp_tuple || conditions_tuple || sunrise_tuple || sunset_tuple || moon_tuple || battery_tuple) {
     prv_save_settings();
   }
 }
@@ -516,9 +573,13 @@ static void prv_unobstructed_change(AnimationProgress progress, void *context) {
   int bar_offset = (PBL_DISPLAY_HEIGHT / 6);
   int bar_y = bounds.size.h - (bar_offset - (bounds.size.h / 12));
 
-  GRect battery_frame = layer_get_frame(s_battery_layer);
-  battery_frame.origin.y = bar_y;
-  layer_set_frame(s_battery_layer, battery_frame);
+  GRect watch_battery_frame = layer_get_frame(s_battery_layer);
+  watch_battery_frame.origin.y = bar_y;
+  layer_set_frame(s_battery_layer, watch_battery_frame);
+
+  GRect phone_battery_frame = layer_get_frame(s_phone_battery_layer);
+  phone_battery_frame.origin.y = bar_y;
+  layer_set_frame(s_phone_battery_layer, phone_battery_frame);
 }
 
 static void prv_unobstructed_did_change(void *context) {
@@ -602,8 +663,18 @@ static void main_window_load(Window *window) {
   int bar_width = bounds.size.w / 1.1;
   int bar_x = (bounds.size.w - bar_width) / 2;
   int bar_y = bounds.size.h - (bar_offset - (bounds.size.h / 12));
+  int phone_bar_width = (bar_width / 2) - (bar_x / 2);
+  if (settings.ShowPhoneBattery) {
+    bar_width = phone_bar_width;
+  }
   s_battery_layer = layer_create(GRect(bar_x, bar_y, bar_width, bar_height));
-  layer_set_update_proc(s_battery_layer, battery_update_proc);
+  layer_set_update_proc(s_battery_layer, watch_battery_update_proc);
+
+  // Create phone battery meter Layer
+  int phone_bar_y = bar_y;
+  int phone_bar_x = (bar_x * 2) + phone_bar_width;
+  s_phone_battery_layer = layer_create(GRect(phone_bar_x, phone_bar_y, phone_bar_width, bar_height));
+  layer_set_update_proc(s_phone_battery_layer, phone_battery_update_proc);
 
   // Create weather TextLayer
   int weather_y = bar_y - info_height - (bounds.size.h / 4.3);
@@ -678,6 +749,7 @@ static void main_window_load(Window *window) {
   layer_add_child(s_window_layer, text_layer_get_layer(s_moon_layer));
   layer_add_child(s_window_layer, text_layer_get_layer(s_bt_icon_layer));
   layer_add_child(s_window_layer, s_battery_layer);
+  layer_add_child(s_window_layer, s_phone_battery_layer);
 
   // Apply saved settings
   prv_update_display();
@@ -709,6 +781,7 @@ static void main_window_unload(Window *window) {
   fonts_unload_custom_font(s_bt_font);
   fonts_unload_custom_font(s_weather_font);
   layer_destroy(s_battery_layer);
+  layer_destroy(s_phone_battery_layer);
 }
 
 static void init() {
@@ -756,6 +829,14 @@ static void init() {
   const int inbox_size = 256;
   const int outbox_size = 256;
   app_message_open(inbox_size, outbox_size);
+
+  // set initial values
+  if (settings.ShowPhoneBattery) {
+    DictionaryIterator *iter;
+    app_message_outbox_begin(&iter);
+    dict_write_uint8(iter, MESSAGE_KEY_REQUEST_BATTERY, 1);
+    app_message_outbox_send();
+  }
 }
 
 static void deinit() {

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -35,7 +35,6 @@ typedef struct ClaySettings {
 
 // An instance of the struct
 static ClaySettings settings;
-static bool s_js_ready;
 
 static Window *s_main_window;
 static TextLayer *s_time_layer;
@@ -383,12 +382,6 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   bool prev_ShowWeather = settings.ShowWeather;
   bool prev_TemperatureUnit = settings.TemperatureUnit;
   bool prev_ShowPhoneBattery = settings.ShowPhoneBattery;
-
-  // chekc if PebbleKit JS is ready
-  Tuple *ready_tuple = dict_find(iterator, MESSAGE_KEY_JSReady);
-  if (ready_tuple) {
-    s_js_ready = true;
-  }
 
   // Check for Clay settings data
   Tuple *bg_color_day_t = dict_find(iterator, MESSAGE_KEY_BackgroundColorDay);

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -104,6 +104,12 @@ module.exports = [
       },
       {
         "type": "toggle",
+        "messageKey": "ShowPhoneBattery",
+        "label": "Show Phone Battery",
+        "defaultValue": false
+      },
+      {
+        "type": "toggle",
         "messageKey": "PeriodicVibrate",
         "label": "Vibrate Hourly",
         "defaultValue": false

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -208,6 +208,70 @@ function sunCalcInfo (pos){
 }
 // End Sun & Moon functions
 
+// battery functions
+function sendBatteryLevel(battery, reportInterval) {
+  var batteryLevel = Math.floor(battery.level * 100);
+  var dictionary = {
+    "BATTERY": batteryLevel
+  };
+  if (batteryLevel % reportInterval == 0) {
+    Pebble.sendAppMessage(dictionary,
+      function(e) {
+        console.log('Battery sent to Pebble successfully!');
+      },
+      function(e) {
+        console.log('Error sending battery to Pebble!');
+      }
+    );
+  }
+}
+function batteryLevelSubscribe(battery) {
+  // Listen for changes in battery level
+  battery.addEventListener('levelchange', function() {
+    sendBatteryLevel(battery, 5);
+  }, false);
+  // also send battery level immediately
+  sendBatteryLevel(battery, 1);
+}
+function batteryLevelUnsubscribe(battery) {
+  // Stop listening for changes in battery level
+  battery.removeEventListener('levelchange', function() {
+    sendBatteryLevel(battery, 5);
+  }, false);
+}
+function batteryStatusFailure() {
+  console.log("Error: Phone Battery function failed to resolve the BatteryManager object.");
+}
+function getBattery() {
+  // Test for old or new battery API
+  if (navigator.battery) {
+    console.log('Success: found navigator.battery API');
+    batteryLevelSubscribe(navigator.battery);
+  } else if (navigator.getBattery) {
+    console.log('Success: found navigator.getBattery API');
+    navigator.getBattery().then(function(newBattery) {
+      batteryLevelSubscribe(newBattery);
+    }, batteryStatusFailure);
+  } else {
+    console.log('Error: no phone battery API found');
+  }
+}
+function stopBattery() {
+  // Test for old or new battery API
+  if (navigator.battery) {
+    console.log('Success: found navigator.battery API');
+    batteryLevelUnsubscribe(navigator.battery);
+  } else if (navigator.getBattery) {
+    console.log('Success: found navigator.getBattery API');
+    navigator.getBattery().then(function(newBattery) {
+      batteryLevelUnsubscribe(newBattery);
+    }, batteryStatusFailure);
+  } else {
+    console.log('Error: no phone battery API found');
+  }
+}
+// end battery functions
+
 // Convert Open-Meteo weather code to human-readable condition
 function weatherCodeToCondition(code) {
   if (code === 0) return 0; //'Clear';
@@ -305,9 +369,12 @@ function getSunInfo() {
 Pebble.addEventListener('ready',
   function(e) {
     console.log('PebbleKit JS ready!');
-    // Get the initial weather
+    // Update s_js_ready on watch
+    Pebble.sendAppMessage({'JSReady': 1});
+    // Get the initial data
     //getSunInfo();
     //getWeather();
+    //getBattery();
   }
 );
 
@@ -322,6 +389,14 @@ Pebble.addEventListener('appmessage',
     // Check if this is a weather refresh request
     if (e.payload['REQUEST_WEATHER']) {
       getWeather();
+    }
+    // Check if this is a battery refresh request
+    if (e.payload['REQUEST_BATTERY']) {
+      getBattery();
+    }
+    // Check if this is a battery unsubscribe request
+    if (e.payload['REQUEST_BATTERY_UNSUBSCRIBE']) {
+      stopBattery();
     }
   }
 );

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -369,8 +369,6 @@ function getSunInfo() {
 Pebble.addEventListener('ready',
   function(e) {
     console.log('PebbleKit JS ready!');
-    // Update s_js_ready on watch
-    Pebble.sendAppMessage({'JSReady': 1});
     // Get the initial data
     //getSunInfo();
     //getWeather();


### PR DESCRIPTION
Adds an optional phone battery bar next to the watch battery bar
- watch battery bar shrinks to make room for the phone battery bar
- phone battery reports in 5% intervals to reduce bluetooth/wakeups