### PR TITLE
add LocalStorage setting for phone battery startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "BluetoothVibrate",
       "ShowPhoneBattery",
       "REQUEST_BATTERY",
-      "REQUEST_BATTERY_UNSUBSCRIBE",
+      "UNSUBSCRIBE_BATTERY",
       "BATTERY"
     ],
     "resources": {

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -526,7 +526,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
         dict_write_uint8(iter, MESSAGE_KEY_REQUEST_BATTERY, 1);
       }
       if (unsibscribeBattery) {
-        dict_write_uint8(iter, MESSAGE_KEY_REQUEST_BATTERY_UNSUBSCRIBE, 1);
+        dict_write_uint8(iter, MESSAGE_KEY_UNSUBSCRIBE_BATTERY, 1);
       }
       app_message_outbox_send();
     }
@@ -822,14 +822,6 @@ static void init() {
   const int inbox_size = 256;
   const int outbox_size = 256;
   app_message_open(inbox_size, outbox_size);
-
-  // set initial values
-  if (settings.ShowPhoneBattery) {
-    DictionaryIterator *iter;
-    app_message_outbox_begin(&iter);
-    dict_write_uint8(iter, MESSAGE_KEY_REQUEST_BATTERY, 1);
-    app_message_outbox_send();
-  }
 }
 
 static void deinit() {

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -372,7 +372,9 @@ Pebble.addEventListener('ready',
     // Get the initial data
     //getSunInfo();
     //getWeather();
-    //getBattery();
+    if (localStorage.getItem('phoneBatteryEnabled') == 1) {
+      getBattery();
+    }
   }
 );
 
@@ -390,10 +392,14 @@ Pebble.addEventListener('appmessage',
     }
     // Check if this is a battery refresh request
     if (e.payload['REQUEST_BATTERY']) {
+      var batteryToggle = 1;
+      localStorage.setItem('phoneBatteryEnabled', batteryToggle);
       getBattery();
     }
     // Check if this is a battery unsubscribe request
-    if (e.payload['REQUEST_BATTERY_UNSUBSCRIBE']) {
+    if (e.payload['UNSUBSCRIBE_BATTERY']) {
+      var batteryToggle = 0;
+      localStorage.setItem('phoneBatteryEnabled', batteryToggle);
       stopBattery();
     }
   }


### PR DESCRIPTION
Adds a LocalStorage setting in the PebbleKit JS script to get and subscribe to battery events at startup if the ShowPhoneBattery watch setting is enabled.

This fixes an issue where battery updates would sometimes stop unless the watchface was reloaded.