### PR TITLE
Add manual coordinates input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BigInfo",
   "author": "drod",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "keywords": [
     "weather",
     "moon",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BigInfo",
   "author": "drod",
-  "version": "1.3",
+  "version": "1.3.0",
   "keywords": [
     "weather",
     "moon",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
       "ShowPhoneBattery",
       "REQUEST_BATTERY",
       "UNSUBSCRIBE_BATTERY",
-      "BATTERY"
+      "BATTERY",
+      "Latitude",
+      "Longitude"
     ],
     "resources": {
       "media": [

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -406,6 +406,8 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   bool prev_TemperatureUnit = settings.TemperatureUnit;
   bool prev_ShowPhoneBattery = settings.ShowPhoneBattery;
   bool prev_AltDate = settings.AltDate;
+  bool prev_Lat = settings.Latitude;
+  bool prev_Lon = settings.Longitude;
 
   // Check for Clay settings data
   Tuple *bg_color_day_t = dict_find(iterator, MESSAGE_KEY_BackgroundColorDay);
@@ -479,10 +481,13 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   }
 
   // check for manual coordinates
+  // TODO: ensure value is stored as int(float * 1000000)
   Tuple *man_lat_t = dict_find(iterator, MESSAGE_KEY_Latitude);
-  Tuple *man_lon_t = dict_find(iterator, MESSAGE_KEY_Longitude);
-  if (man_lat_t && man_lon_t) {
+  if (man_lat_t) {
     settings.Latitude = (int)man_lat_t->value->int32;
+  }
+  Tuple *man_lon_t = dict_find(iterator, MESSAGE_KEY_Longitude);
+  if (man_lon_t) {
     settings.Longitude = (int)man_lon_t->value->int32;
   }
 
@@ -554,7 +559,8 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     bool requestWeather = ((prev_TemperatureUnit != settings.TemperatureUnit) || !prev_ShowWeather) && settings.ShowWeather;
     bool requestBattery = (!prev_ShowPhoneBattery && settings.ShowPhoneBattery);
     bool unsibscribeBattery = (prev_ShowPhoneBattery && !settings.ShowPhoneBattery);
-    if (requestSun || requestWeather || requestBattery || unsibscribeBattery) {
+    bool sendCoordinates = (prev_Lat != settings.Latitude) || (prev_Lon != settings.Longitude);
+    if (requestSun || requestWeather || requestBattery || unsibscribeBattery || sendCoordinates) {
       DictionaryIterator *iter;
       app_message_outbox_begin(&iter);
       if (requestSun) {
@@ -568,6 +574,10 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
       }
       if (unsibscribeBattery) {
         dict_write_uint8(iter, MESSAGE_KEY_UNSUBSCRIBE_BATTERY, 1);
+      }
+      if (sendCoordinates) {
+        dict_write_uint8(iter, MESSAGE_KEY_Latitude, settings.Latitude);
+        dict_write_uint8(iter, MESSAGE_KEY_Longitude, settings.Longitude);
       }
       app_message_outbox_send();
     }

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -589,14 +589,15 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     prv_update_display();
 
     // Request data when a setting was changed
+    bool updateCoordinates = (prev_Lat != settings.Latitude) || (prev_Lon != settings.Longitude);
     bool requestSun = (!prev_ShowSun && settings.ShowSun) ||
                    (!prev_ShowMoon && settings.ShowMoon) ||
-                   (!prev_NightTheme && settings.NightTheme);
-    bool requestWeather = ((prev_TemperatureUnit != settings.TemperatureUnit) || !prev_ShowWeather) && settings.ShowWeather;
+                   (!prev_NightTheme && settings.NightTheme) ||
+                   (updateCoordinates && (settings.ShowSun || settings.ShowMoon || settings.NightTheme));
+    bool requestWeather = ((prev_TemperatureUnit != settings.TemperatureUnit) || !prev_ShowWeather || updateCoordinates) && settings.ShowWeather;
     bool requestBattery = (!prev_ShowPhoneBattery && settings.ShowPhoneBattery);
     bool unsibscribeBattery = (prev_ShowPhoneBattery && !settings.ShowPhoneBattery);
-    bool sendCoordinates = (prev_Lat != settings.Latitude) || (prev_Lon != settings.Longitude);
-    if (requestSun || requestWeather || requestBattery || unsibscribeBattery || sendCoordinates) {
+    if (requestSun || requestWeather || requestBattery || unsibscribeBattery || updateCoordinates) {
       DictionaryIterator *iter;
       app_message_outbox_begin(&iter);
       if (requestSun) {
@@ -611,7 +612,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
       if (unsibscribeBattery) {
         dict_write_uint8(iter, MESSAGE_KEY_UNSUBSCRIBE_BATTERY, 1);
       }
-      if (sendCoordinates) {
+      if (updateCoordinates) {
         // Send empty string if coordinates are not set, otherwise send scaled int
         if (strcmp(man_lat_t->value->cstring,"") == 0) {
           dict_write_cstring(iter, MESSAGE_KEY_Latitude, "");

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -309,8 +309,8 @@ static void update_moon() {
 
 int parse_coordinates(char *coor_str) {
   char *dot = strchr(coor_str, '.');
-  int32_t whole_part = 0;
-  int32_t frac_part = 0;
+  int whole_part = 0;
+  int frac_part = 0;
   
   if (dot) {
     // Null-terminate at the dot to isolate the whole number
@@ -613,15 +613,15 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
       }
       if (sendCoordinates) {
         // Send empty string if coordinates are not set, otherwise send scaled int
-        if (man_lat_t->value->cstring == "") {
-          dict_write_string(iter, MESSAGE_KEY_Latitude, "");
+        if (strcmp(man_lat_t->value->cstring,"") == 0) {
+          dict_write_cstring(iter, MESSAGE_KEY_Latitude, "");
         } else {
-          dict_write_uint8(iter, MESSAGE_KEY_Latitude, settings.Latitude);
+          dict_write_int32(iter, MESSAGE_KEY_Latitude, settings.Latitude);
         }
-        if (man_lon_t->value->cstring == "") {
-          dict_write_string(iter, MESSAGE_KEY_Longitude, "");
+        if (strcmp(man_lon_t->value->cstring,"") == 0) {
+          dict_write_cstring(iter, MESSAGE_KEY_Longitude, "");
         } else {
-          dict_write_uint8(iter, MESSAGE_KEY_Longitude, settings.Longitude);
+          dict_write_int32(iter, MESSAGE_KEY_Longitude, settings.Longitude);
         }
       }
       app_message_outbox_send();

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -484,11 +484,13 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   // TODO: ensure value is stored as int(float * 1000000)
   Tuple *man_lat_t = dict_find(iterator, MESSAGE_KEY_Latitude);
   if (man_lat_t) {
-    settings.Latitude = (int)man_lat_t->value->int32;
+    float latFloat = man_lat_t->value->int32 / 1.0f;
+    settings.Latitude = (int)(latFloat * 1000000);
   }
   Tuple *man_lon_t = dict_find(iterator, MESSAGE_KEY_Longitude);
   if (man_lon_t) {
-    settings.Longitude = (int)man_lon_t->value->int32;
+    float lonFloat = man_lon_t->value->int32 / 1.0f;
+    settings.Longitude = (int)(lonFloat * 1000000);
   }
 
   // Check for weather data

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -307,6 +307,43 @@ static void update_moon() {
   text_layer_set_text(s_moon_layer, moon_phase[settings.MoonPhase]);
 }
 
+int parse_coordinates(char *coor_str) {
+  char *dot = strchr(coor_str, '.');
+  int32_t whole_part = 0;
+  int32_t frac_part = 0;
+  
+  if (dot) {
+    // Null-terminate at the dot to isolate the whole number
+    *dot = '\0';
+    whole_part = atoi(coor_str);
+    
+    // Move to the character after the dot
+    char *fractional_string = dot + 1;
+    int len = strlen(fractional_string);
+    frac_part = atoi(fractional_string);
+    
+    // Scale the fractional part to 6 decimal places
+    // e.g., if ".5" it becomes 500000. If ".5074" it becomes 507400
+    for (int i = len; i < 6; i++) {
+      frac_part *= 10;
+    }
+    // If the fractional part was longer than 6, truncate it
+    for (int i = len; i > 6; i--) {
+      frac_part /= 10;
+    }
+  } else {
+    // No decimal point found
+    whole_part = atoi(coor_str);
+  }
+
+  // Combine them (handling negative coordinates like -74.00)
+  if (whole_part < 0 || coor_str[0] == '-') {
+    return (whole_part * 1000000) - frac_part;
+  } else {
+    return (whole_part * 1000000) + frac_part;
+  }
+}
+
 static void tick_handler(struct tm *tick_time, TimeUnits units_changed) {
   // run every minute
   update_time();
@@ -481,16 +518,13 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   }
 
   // check for manual coordinates
-  // TODO: ensure value is stored as int(float * 1000000)
   Tuple *man_lat_t = dict_find(iterator, MESSAGE_KEY_Latitude);
   if (man_lat_t) {
-    float latFloat = man_lat_t->value->int32 / 1.0f;
-    settings.Latitude = (int)(latFloat * 1000000);
+    settings.Latitude = parse_coordinates(man_lat_t->value->cstring);
   }
   Tuple *man_lon_t = dict_find(iterator, MESSAGE_KEY_Longitude);
   if (man_lon_t) {
-    float lonFloat = man_lon_t->value->int32 / 1.0f;
-    settings.Longitude = (int)(lonFloat * 1000000);
+    settings.Longitude = parse_coordinates(man_lon_t->value->cstring);
   }
 
   // Check for weather data

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -569,7 +569,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   }
 
   // Save and apply if any settings were changed
-  if (bg_color_day_t || text_color_day_t || bg_color_night_t || text_color_night_t || night_theme_t || temp_unit_t || show_weather_t || show_date_t || show_date2_t || alt_date_t || show_steps_t || show_sun_t || show_moon_t || show_phone_battery_t) {
+  if (bg_color_day_t || text_color_day_t || bg_color_night_t || text_color_night_t || night_theme_t || temp_unit_t || show_weather_t || show_date_t || show_date2_t || alt_date_t || show_steps_t || show_sun_t || show_moon_t || show_phone_battery_t || man_lat_t || man_lon_t) {
     
     // if show battery was toggled
     if (prev_ShowPhoneBattery != settings.ShowPhoneBattery) {
@@ -612,8 +612,17 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
         dict_write_uint8(iter, MESSAGE_KEY_UNSUBSCRIBE_BATTERY, 1);
       }
       if (sendCoordinates) {
-        dict_write_uint8(iter, MESSAGE_KEY_Latitude, settings.Latitude);
-        dict_write_uint8(iter, MESSAGE_KEY_Longitude, settings.Longitude);
+        // Send empty string if coordinates are not set, otherwise send scaled int
+        if (man_lat_t->value->cstring == "") {
+          dict_write_string(iter, MESSAGE_KEY_Latitude, "");
+        } else {
+          dict_write_uint8(iter, MESSAGE_KEY_Latitude, settings.Latitude);
+        }
+        if (man_lon_t->value->cstring == "") {
+          dict_write_string(iter, MESSAGE_KEY_Longitude, "");
+        } else {
+          dict_write_uint8(iter, MESSAGE_KEY_Longitude, settings.Longitude);
+        }
       }
       app_message_outbox_send();
     }

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -25,6 +25,8 @@ typedef struct ClaySettings {
   bool ShowPhoneBattery;
   bool PeriodicVibrate;
   bool BluetoothVibrate;
+  int Latitude;
+  int Longitude;
   // storage
   bool IsDay;
   int SunriseTime;
@@ -474,6 +476,14 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   Tuple *disconnect_alert_t = dict_find(iterator, MESSAGE_KEY_BluetoothVibrate);
   if (disconnect_alert_t) {
     settings.BluetoothVibrate = disconnect_alert_t->value->int32 == 1;
+  }
+
+  // check for manual coordinates
+  Tuple *man_lat_t = dict_find(iterator, MESSAGE_KEY_Latitude);
+  Tuple *man_lon_t = dict_find(iterator, MESSAGE_KEY_Longitude);
+  if (man_lat_t && man_lon_t) {
+    settings.Latitude = (int)man_lat_t->value->int32;
+    settings.Longitude = (int)man_lon_t->value->int32;
   }
 
   // Check for weather data

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -133,6 +133,27 @@ module.exports = [
         "messageKey": "BluetoothVibrate",
         "label": "Vibrate when Bluetooth Disconnects",
         "defaultValue": false
+      },
+      {
+        "type": "input",
+        "messageKey": "Latitude",
+        "defaultValue": "",
+        "label": "Manual Location - Latitude",
+        "attributes": {
+          "placeholder": "eg: 40.7127 (leave blank to use GPS)",
+          "type": "number"
+        }
+      },
+      {
+        "type": "input",
+        "messageKey": "Longitude",
+        "defaultValue": "",
+        "label": "Manual Location - Longitude",
+        "description": "Leave both blank to use GPS location for weather & sun times. You can use <a href =https://www.google.com/maps>Google Maps</a> or <a href =https://www.openstreetmap.org/>OpenStreetMap</a> to find latitude & longitude.",
+        "attributes": {
+          "placeholder": "eg: -74.0061 (leave blank to use GPS)",
+          "type": "number"
+        }
       }
     ]
   },

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -141,7 +141,10 @@ module.exports = [
         "label": "Manual Location - Latitude",
         "attributes": {
           "placeholder": "eg: 40.7127 (leave blank to use GPS)",
-          "type": "number"
+          "type": "number",
+          "min": "-90",
+          "max": "90",
+          "step": ".000001"
         }
       },
       {
@@ -152,7 +155,10 @@ module.exports = [
         "description": "Leave both blank to use GPS location for weather & sun times. You can use <a href =https://www.google.com/maps>Google Maps</a> or <a href =https://www.openstreetmap.org/>OpenStreetMap</a> to find latitude & longitude.",
         "attributes": {
           "placeholder": "eg: -74.0061 (leave blank to use GPS)",
-          "type": "number"
+          "type": "number",
+          "min": "-180",
+          "max": "180",
+          "step": ".000001"
         }
       }
     ]

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -323,6 +323,8 @@ function weatherInfo(pos) {
       var sunsetParts = json.daily.sunset[0].split('T')[1].split(':');                                                                     
       var sunriseint = parseInt(sunriseParts[0]) * 100 + parseInt(sunriseParts[1]);                                                        
       var sunsetint = parseInt(sunsetParts[0]) * 100 + parseInt(sunsetParts[1]);
+      console.log('sunrise: ' + sunriseint);
+      console.log('sunset: ' + sunsetint);
 
       // Assemble dictionary
       var dictionary = {
@@ -418,6 +420,7 @@ Pebble.addEventListener('appmessage',
 
     // Check for manual coordinates
     if (dict.hasOwnProperty('Latitude') && dict.hasOwnProperty('Longitude')) {
+      console.log('manual coordinates recieved');
       var lat = dict['Latitude'];
       var lon = dict['Longitude'];
       // If BOTH fields have content and are not just empty strings save to localStorage
@@ -425,10 +428,13 @@ Pebble.addEventListener('appmessage',
         var manualCoordinates = 1;
         localStorage.setItem('Latitude', lat);
         localStorage.setItem('Longitude', lon);
+        console.log('latitude: ' + (lat / 1000000));
+        console.log('longitude: ' + (lon / 1000000));
       } else {
         var manualCoordinates = 0;
         localStorage.removeItem('Latitude');
         localStorage.removeItem('Longitude');
+        console.log('manual coordinates disabled');
       }
       localStorage.setItem('manualCoordinates', manualCoordinates);
     }

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -176,7 +176,7 @@ SunCalc.getMoonIllumination = function (date) {
     angle: angle
   };
 };
-function sunCalcInfo (pos){
+function sunInfo (pos){
   var lat = pos.coords.latitude;
   var lon = pos.coords.longitude;
   var d = new Date();
@@ -242,7 +242,7 @@ function batteryLevelUnsubscribe(battery) {
 function batteryStatusFailure() {
   console.log("Error: Phone Battery function failed to resolve the BatteryManager object.");
 }
-function getBattery() {
+function getBatteryInfo() {
   // Test for old or new battery API
   if (navigator.battery) {
     console.log('Success: found navigator.battery API');
@@ -290,7 +290,7 @@ function weatherCodeToCondition(code) {
   return 15; //unknown
 }
 
-function locationSuccessWeather(pos) {
+function weatherInfo(pos) {
   // Construct Open-Meteo API URL
   var url = 'https://api.open-meteo.com/v1/forecast?' +
       'latitude=' + pos.coords.latitude +
@@ -349,20 +349,52 @@ function locationError(err) {
   console.log('Error requesting location!');
 }
 
-function getWeather() {
-  navigator.geolocation.getCurrentPosition(
-    locationSuccessWeather,
-    locationError,
-    { timeout: 15000, maximumAge: 60000 }
-  );
+function getWeatherInfo() {
+  if (localStorage.getItem('manualCoordinates') == 1) {
+    const mockPosition = {
+      coords: {
+        latitude: (localStorage.getItem('Latitude') / 1000000),
+        longitude: (localStorage.getItem('Longitude') / 1000000),
+        altitude: null,
+        accuracy: 100,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null
+      },
+      timestamp: Date.now()
+    };
+    weatherInfo(mockPosition);
+  } else {
+    navigator.geolocation.getCurrentPosition(
+      weatherInfo,
+      locationError,
+      { timeout: 15000, maximumAge: 60000 }
+    );
+  }
 }
 
 function getSunInfo() {
-  navigator.geolocation.getCurrentPosition(
-    sunCalcInfo,
-    locationError,
-    { timeout: 15000, maximumAge: 60000 }
-  );
+  if (localStorage.getItem('manualCoordinates') == 1) {
+    const mockPosition = {
+      coords: {
+        latitude: (localStorage.getItem('Latitude') / 1000000),
+        longitude: (localStorage.getItem('Longitude') / 1000000),
+        altitude: null,
+        accuracy: 100,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null
+      },
+      timestamp: Date.now()
+    };
+    sunInfo(mockPosition);
+  } else {
+    navigator.geolocation.getCurrentPosition(
+      sunInfo,
+      locationError,
+      { timeout: 15000, maximumAge: 60000 }
+    );
+  }
 }
 
 // Listen for when the watchface is opened
@@ -371,9 +403,9 @@ Pebble.addEventListener('ready',
     console.log('PebbleKit JS ready!');
     // Get the initial data
     //getSunInfo();
-    //getWeather();
+    //getWeatherInfo();
     if (localStorage.getItem('phoneBatteryEnabled') == 1) {
-      getBattery();
+      getBatteryInfo();
     }
   }
 );
@@ -382,22 +414,41 @@ Pebble.addEventListener('ready',
 Pebble.addEventListener('appmessage',
   function(e) {
     console.log('AppMessage received!');
+    var dict = e.payload;
+
+    // Check for manual coordinates
+    if (dict.hasOwnProperty('Latitude') && dict.hasOwnProperty('Longitude')) {
+      var lat = dict['Latitude'];
+      var lon = dict['Longitude'];
+      // If BOTH fields have content and are not just empty strings save to localStorage
+      if (lat !== "" && lon !== "" && lat !== undefined && lon !== undefined) {
+        var manualCoordinates = 1;
+        localStorage.setItem('Latitude', lat);
+        localStorage.setItem('Longitude', lon);
+      } else {
+        var manualCoordinates = 0;
+        localStorage.removeItem('Latitude');
+        localStorage.removeItem('Longitude');
+      }
+      localStorage.setItem('manualCoordinates', manualCoordinates);
+    }
+
     // Check if this is a sun info refresh request
-    if (e.payload['REQUEST_SUN']) {
+    if (dict['REQUEST_SUN']) {
       getSunInfo();
     }
     // Check if this is a weather refresh request
-    if (e.payload['REQUEST_WEATHER']) {
-      getWeather();
+    if (dict['REQUEST_WEATHER']) {
+      getWeatherInfo();
     }
     // Check if this is a battery refresh request
-    if (e.payload['REQUEST_BATTERY']) {
+    if (dict['REQUEST_BATTERY']) {
       var batteryToggle = 1;
       localStorage.setItem('phoneBatteryEnabled', batteryToggle);
-      getBattery();
+      getBatteryInfo();
     }
     // Check if this is a battery unsubscribe request
-    if (e.payload['UNSUBSCRIBE_BATTERY']) {
+    if (dict['UNSUBSCRIBE_BATTERY']) {
       var batteryToggle = 0;
       localStorage.setItem('phoneBatteryEnabled', batteryToggle);
       stopBattery();


### PR DESCRIPTION
### Summary
Adds support for user-specified manual coordinates to override phone GPS location for weather and sunrise/sunset calculations.

### Changes
- `src/pkjs/config.js`: Added manual latitude/longitude input fields with validation (lat: -90 to 90, lon: -180 to 180, precision 0.000001).
- `src/c/main.c`: Added Latitude and Longitude fields to settings struct. Added `parse_coordinates()` function to convert user input (float) to scaled integer (value * 1000000) for memory-efficient storage on Pebble. Modified inbox callback to parse coordinates and send them to PebbleKit JS when changed.
- `src/pkjs/index.js`: Updated weather/sun info functions to use stored manual coordinates when manualCoordinates flag is set, otherwise falls back to phone GPS. Added appmessage handler to receive coordinate updates from watch.
- `package.json`: Added Latitude and Longitude to MESSAGE_KEY constants, updated version to 1.4.0.


Closes: https://github.com/drod0258/BigInfoPebble/issues/6