### PR TITLE
fix 12-hour time formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,13 +75,13 @@
           "type": "font",
           "name": "FONT_TALLBOLD_49",
           "file": "fonts/tallbolder.ttf",
-          "characterRegex": "[:0-9]"
+          "characterRegex": "[0-9: ]"
         },
         {
           "type": "font",
           "name": "FONT_TALLBOLD_64",
           "file": "fonts/tallbolder.ttf",
-          "characterRegex": "[:0-9]",
+          "characterRegex": "[0-9: ]",
           "targetPlatforms": [
             "emery"
           ]

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -297,8 +297,24 @@ static void update_steps() {
 static void update_sun() {
   static char sunrise_buffer[6];
   static char sunset_buffer[6];
-  snprintf(sunrise_buffer, sizeof(sunrise_buffer), "%02d:%02d", (settings.SunriseTime / 100), (settings.SunriseTime % 100));
-  snprintf(sunset_buffer, sizeof(sunset_buffer), "%02d:%02d", (settings.SunsetTime / 100), (settings.SunsetTime % 100));
+  int sunriseHour = (settings.SunriseTime / 100);
+  int sunriseMinute = (settings.SunriseTime % 100);
+  int sunsetHour = (settings.SunsetTime / 100);
+  int sunsetMinute = (settings.SunsetTime % 100);
+  if (!clock_is_24h_style()) {
+    if (sunriseHour > 12) {
+      sunriseHour -= 12;
+    } else if (sunriseHour == 0) {
+      sunriseHour = 12;
+    }
+    if (sunsetHour > 12) {
+      sunsetHour -= 12;
+    } else if (sunsetHour == 0) {
+      sunsetHour = 12;
+    }
+  }
+  snprintf(sunrise_buffer, sizeof(sunrise_buffer), clock_is_24h_style() ? "%02d:%02d" : "%d:%02d", sunriseHour, sunriseMinute);
+  snprintf(sunset_buffer, sizeof(sunset_buffer), clock_is_24h_style() ? "%02d:%02d" : "%d:%02d", sunsetHour, sunsetMinute);
   text_layer_set_text(s_sunrise_layer, sunrise_buffer);
   text_layer_set_text(s_sunset_layer, sunset_buffer);
 }

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -247,7 +247,7 @@ static void update_time() {
 
   static char s_time_buffer[8];
   strftime(s_time_buffer, sizeof(s_time_buffer), clock_is_24h_style() ?
-                                                    "%H:%M" : "%I:%M", tick_time);
+                                                    "%H:%M" : "%l:%M", tick_time);
   text_layer_set_text(s_time_layer, s_time_buffer);
 }
 


### PR DESCRIPTION
### Summary
fixes the 12-hour time display by removing the leading zeros from the time and impelments logic to correctly format the sunrise and sunset times when the watch is set to 12-hour mode

### Changes
- Main Time Display: Updated the time string format from `%I:%M` to `%l:%M` to remove the leading zero padding
- Sun times: Added logic to convert raw 24-hour time values, including handling for noon/midnight transitions 

Closes: https://github.com/drod0258/BigInfoPebble/issues/8