### PR TITLE
Add UK (Day DD Mon) and custom date formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,9 @@
       "ShowCharging",
       "Latitude",
       "Longitude",
-      "JSReady"
+      "JSReady",
+      "DateFormat",
+      "CustomDate"
     ],
     "resources": {
       "media": [

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -3,6 +3,15 @@
 // Persistent storage key
 #define SETTINGS_KEY 1
 
+// Date format options (DateFormat setting)
+enum {
+  DATE_FORMAT_DEFAULT = 0, // Day Mon DD  (e.g. Sat Jun 07)
+  DATE_FORMAT_ISO     = 1, // YYYY-MM-DD  (e.g. 2026-06-07)
+  DATE_FORMAT_DMY     = 2, // Day DD Mon  (e.g. Sat 07 Jun)
+  DATE_FORMAT_CUSTOM  = 3, // user-supplied strftime pattern (CustomDate)
+};
+#define DATE_FORMAT_UNSET -1
+
 // Define our settings struct
 typedef struct ClaySettings {
   // user settings
@@ -85,6 +94,10 @@ typedef struct ClaySettings {
   bool unsibscribeBattery;
   bool updateCoordinates;
   bool requestJS;
+  // Date format — appended to the end of the struct so older persisted
+  // settings (saved before these fields existed) load without corruption.
+  int DateFormat;
+  char CustomDate[24];
 } ClaySettings;
 
 // An instance of the struct
@@ -170,6 +183,8 @@ static void prv_default_settings() {
   settings.ShowDate = false;
   settings.ShowDate2 = false;
   settings.AltDate = false;
+  settings.DateFormat = DATE_FORMAT_UNSET;
+  strncpy(settings.CustomDate, "%a %d %b", sizeof(settings.CustomDate));
   settings.ShowWeather = false;
   settings.TemperatureUnit = false;
   settings.WeatherInterval = 3;
@@ -279,6 +294,13 @@ static void prv_load_settings() {
   prv_default_settings();
   // Then override with any saved values
   persist_read_data(SETTINGS_KEY, &settings, sizeof(settings));
+
+  // Migrate the legacy AltDate toggle to the DateFormat setting. Settings saved
+  // before DateFormat existed leave it at DATE_FORMAT_UNSET, so derive the value
+  // from AltDate once to preserve the user's previous choice.
+  if (settings.DateFormat == DATE_FORMAT_UNSET) {
+    settings.DateFormat = settings.AltDate ? DATE_FORMAT_ISO : DATE_FORMAT_DEFAULT;
+  }
 }
 
 // Apply settings to UI elements
@@ -383,15 +405,36 @@ static void update_date() {
   time_t now = time(NULL);
   struct tm *tick_time = localtime(&now);
 
-  static char s_date_buffer[16];
-  static char s_date2_buffer[16];
-  if (settings.AltDate) {
-    strftime(s_date_buffer, sizeof(s_date_buffer), "%Y-%m-%d", tick_time);
-    strftime(s_date2_buffer, sizeof(s_date2_buffer), "%A", tick_time);
-  } else {
-    strftime(s_date_buffer, sizeof(s_date_buffer), "%a %b %d", tick_time);
-    strftime(s_date2_buffer, sizeof(s_date2_buffer), "%Y", tick_time);
+  static char s_date_buffer[32];
+  static char s_date2_buffer[32];
+
+  // Primary line is the chosen format; the additional date line (s_date2,
+  // shown only on tall displays) pairs the weekday with ISO and the year
+  // with every other format.
+  const char *primary_format;
+  const char *secondary_format;
+  switch (settings.DateFormat) {
+    case DATE_FORMAT_ISO:
+      primary_format = "%Y-%m-%d";
+      secondary_format = "%A";
+      break;
+    case DATE_FORMAT_DMY:
+      primary_format = "%a %d %b";
+      secondary_format = "%Y";
+      break;
+    case DATE_FORMAT_CUSTOM:
+      primary_format = (settings.CustomDate[0] != '\0') ? settings.CustomDate : "%a %b %d";
+      secondary_format = "%Y";
+      break;
+    case DATE_FORMAT_DEFAULT:
+    default:
+      primary_format = "%a %b %d";
+      secondary_format = "%Y";
+      break;
   }
+
+  strftime(s_date_buffer, sizeof(s_date_buffer), primary_format, tick_time);
+  strftime(s_date2_buffer, sizeof(s_date2_buffer), secondary_format, tick_time);
   text_layer_set_text(s_date_layer, s_date_buffer);
   text_layer_set_text(s_date2_layer, s_date2_buffer);
 }
@@ -804,7 +847,22 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
   if (alt_date_t) {
     settings.AltDate = alt_date_t->value->int32 == 1;
   }
-  if (prev_AltDate != settings.AltDate) {
+  Tuple *date_format_t = dict_find(iterator, MESSAGE_KEY_DateFormat);
+  if (date_format_t) {
+    // Clay's select component sends its value as a string (e.g. "2"), so accept
+    // either a string or a raw integer.
+    if (date_format_t->type == TUPLE_CSTRING) {
+      settings.DateFormat = atoi(date_format_t->value->cstring);
+    } else {
+      settings.DateFormat = (int)date_format_t->value->int32;
+    }
+  }
+  Tuple *custom_date_t = dict_find(iterator, MESSAGE_KEY_CustomDate);
+  if (custom_date_t) {
+    strncpy(settings.CustomDate, custom_date_t->value->cstring, sizeof(settings.CustomDate) - 1);
+    settings.CustomDate[sizeof(settings.CustomDate) - 1] = '\0';
+  }
+  if (date_format_t || custom_date_t || (prev_AltDate != settings.AltDate)) {
     update_date();
   }
   Tuple *show_weather_t = dict_find(iterator, MESSAGE_KEY_ShowWeather);
@@ -944,7 +1002,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     time_color_night_t || date_color_night_t || weather_color_night_t || health_color_night_t || 
     sun_color_night_t || moon_color_night_t || battery_outline_color_night_t || battery_charging_color_night_t || 
     battery_full_color_night_t || battery_mid_color_night_t || battery_low_color_night_t || 
-    show_date_t || show_date2_t || alt_date_t || show_steps_t || show_hr_t || 
+    show_date_t || show_date2_t || alt_date_t || date_format_t || custom_date_t || show_steps_t || show_hr_t ||
     show_weather_t || temp_unit_t || weahter_interval_t || show_sun_t || show_moon_t || man_lat_t || man_lon_t || 
     show_charging_t || battery_mid_percent_t || battery_low_percent_t || 
     show_phone_battery_t || periodic_vibrate_t || periodic_sound_t || 
@@ -1336,8 +1394,9 @@ static void init() {
   app_message_register_outbox_failed(outbox_failed_callback);
   app_message_register_outbox_sent(outbox_sent_callback);
 
-  // Open AppMessage
-  const int inbox_size = 512;
+  // Open AppMessage. The inbox must hold the full Clay settings payload, which
+  // grew past the previous 512-byte buffer once the date format string was added.
+  const int inbox_size = 2048;
   const int outbox_size = 256;
   app_message_open(inbox_size, outbox_size);
 }

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -259,11 +259,26 @@ module.exports = [
         "capabilities": ["NOT_DISPLAY_144x168"]
       },
       {
-        "type": "toggle",
-        "messageKey": "AltDate",
-        "label": "Alternate Date Format",
-        "description": "Toggle between `Day Mon DD` and `YYYY-MM-DD`",
-        "defaultValue": false
+        "type": "select",
+        "messageKey": "DateFormat",
+        "label": "Date Format",
+        "defaultValue": 0,
+        "options": [
+          { "label": "Day Mon DD  (Sat Jun 07)", "value": 0 },
+          { "label": "YYYY-MM-DD  (2026-06-07)", "value": 1 },
+          { "label": "Day DD Mon  (Sat 07 Jun)", "value": 2 },
+          { "label": "Custom", "value": 3 }
+        ]
+      },
+      {
+        "type": "input",
+        "messageKey": "CustomDate",
+        "label": "Custom Date Format",
+        "defaultValue": "%a %d %b",
+        "description": "Only used when Date Format is set to `Custom`. Uses strftime tokens — e.g. `%a`=Sat, `%A`=Saturday, `%d`=07, `%b`=Jun, `%B`=June, `%m`=06, `%Y`=2026.",
+        "attributes": {
+          "placeholder": "%a %d %b"
+        }
       }
     ]
   },


### PR DESCRIPTION
Closes #28.

Replaces the single "Alternate Date Format" toggle with a **Date Format** dropdown plus a fully custom `strftime` option.

| | Format | Example |
|---|---|---|
| 0 | Default — `Day Mon DD` | `Sat Jun 07` |
| 1 | ISO 8601 — `YYYY-MM-DD` | `2026-06-07` |
| 2 | UK — `Day DD Mon` | `Sat 07 Jun` |
| 3 | Custom — user `strftime` string (`CustomDate`) | `%A %d %B` → `Saturday 07 June` |

### Implementation notes
- **Backward-compatible persistence:** `DateFormat` (int) and `CustomDate` (`char[24]`) are appended to the end of the `ClaySettings` struct, so settings saved before these fields existed still load without corruption.
- **Migration:** on first load after upgrade, `DateFormat` is derived once from the old `AltDate` value (`true` → ISO, `false` → Default), so existing users keep their current format. The `AltDate` field/key are retained for this.
- The additional date line keeps its previous pairing (weekday with ISO, year with everything else).

### Two fixes found while testing on-device
- Clay's `select` sends its value as a **string**, so `DateFormat` is parsed with `atoi` when it arrives as a cstring (falling back to int).
- Adding the `CustomDate` string pushed the full Clay settings payload past the **512-byte AppMessage inbox**, which silently dropped every save. The inbox buffer is raised to **2048 bytes**.

### Testing
Built for all six platforms (aplite → gabbro) and verified on a physical **Pebble Time 2 (emery)**: each preset, a custom pattern, and migration of an existing setting all confirmed on-watch.

Opened as a **draft** for your review — happy to adjust the preset list, labels, or approach.
