### PR TITLE
Keep time centered for single-digit hours

### DIFF
--- a/src/c/main.c
+++ b/src/c/main.c
@@ -376,7 +376,14 @@ static void update_time() {
   static char s_time_buffer[8];
   strftime(s_time_buffer, sizeof(s_time_buffer), clock_is_24h_style() ?
                                                     "%H:%M" : "%l:%M", tick_time);
-  text_layer_set_text(s_time_layer, s_time_buffer);
+  // "%l" blank-pads single-digit hours (e.g. " 9:00"). With center alignment the
+  // leading space gets counted, pushing the visible digits off-center. Skip it so
+  // the time stays centered whether the hour has one or two digits.
+  char *time_text = s_time_buffer;
+  if (time_text[0] == ' ') {
+    time_text++;
+  }
+  text_layer_set_text(s_time_layer, time_text);
 }
 
 static void update_date() {


### PR DESCRIPTION
Closes #29.

In 12-hour mode the hour is formatted with `%l`, which blank-pads single-digit hours (`" 9:00"`). The time `TextLayer` is center-aligned, so the leading space is counted in the width and pushes the visible digits right of center — two-digit hours look centered while single-digit hours look shifted.

This skips the leading space before setting the text, so the visible glyphs stay centered regardless of hour width. 24-hour mode is unaffected (`%H` is zero-padded).

### Testing
Verified before/after on a physical **Pebble Time 2 (emery)** in 12-hour mode: `9:00` now sits centered instead of shifted right.

Opened as a **draft** for your review.
